### PR TITLE
Fix signal assignment per project

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,5 +15,7 @@
 | `GET` | `/api/device-type-signals` | Сигналы по типам устройств |
 | `PUT` | `/api/device-type-signals` | Создать или обновить запись |
 | `DELETE` | `/api/device-type-signals/:deviceType` | Удалить запись |
+| `POST` | `/api/import/assign-signals/:deviceType?projectId=ID` | Назначить сигналы устройствам указанного типа в проекте |
+| `POST` | `/api/import/assign-signals-all?projectId=ID` | Назначить сигналы всем типам устройств в проекте |
 
 Также доступны маршруты для импорта данных (`/api/import`), экспорта (`/api/exports`) и управления проектами (`/api/projects`).

--- a/server/src/controllers/importController.ts
+++ b/server/src/controllers/importController.ts
@@ -78,13 +78,15 @@ export class ImportController {
   static async assignSignalsToDevicesByType(req: Request, res: Response): Promise<void> {
     try {
       const { deviceType } = req.params;
+      const { projectId } = req.query;
       
       if (!deviceType) {
         res.status(400).json({ success: false, message: 'Не указан тип устройства' });
         return;
       }
       
-      const result = await ImportService.assignSignalsToDevicesByType(deviceType);
+      const pid = projectId ? parseInt(projectId as string, 10) : undefined;
+      const result = await ImportService.assignSignalsToDevicesByType(deviceType, pid);
       
       res.json(result);
     } catch (error) {
@@ -102,7 +104,9 @@ export class ImportController {
   static async assignSignalsToAllDeviceTypes(req: Request, res: Response): Promise<void> {
     try {
       console.log('Начато назначение сигналов всем типам устройств');
-      const result = await ImportService.assignSignalsToAllDeviceTypes();
+      const { projectId } = req.query;
+      const pid = projectId ? parseInt(projectId as string, 10) : undefined;
+      const result = await ImportService.assignSignalsToAllDeviceTypes(pid);
       
       res.json(result);
     } catch (error) {

--- a/server/src/services/ImportService.ts
+++ b/server/src/services/ImportService.ts
@@ -298,7 +298,7 @@ export class ImportService {
    * Привязка сигналов к устройствам на основе их типа
    * @param deviceType Тип устройства
    */
-  static async assignSignalsToDevicesByType(deviceType: string): Promise<{ success: boolean; message: string; count?: number }> {
+  static async assignSignalsToDevicesByType(deviceType: string, projectId?: number): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       // Получаем все сигналы для данной категории (типа устройства)
       const signals = await Signal.findAll({
@@ -314,8 +314,14 @@ export class ImportService {
       
       // Получаем все устройства данного типа
       const { DeviceReference } = require('../models/DeviceReference');
+      const whereClause: any = { deviceType };
+
+      if (projectId) {
+        whereClause.projectId = projectId;
+      }
+
       const devices = await DeviceReference.findAll({
-        where: { deviceType }
+        where: whereClause
       });
       
       if (devices.length === 0) {
@@ -454,7 +460,7 @@ export class ImportService {
   /**
    * Назначение сигналов всем типам устройств
    */
-  static async assignSignalsToAllDeviceTypes(): Promise<{ success: boolean; message: string; count?: number }> {
+  static async assignSignalsToAllDeviceTypes(projectId?: number): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       console.log('Начато назначение сигналов всем типам устройств');
       
@@ -492,7 +498,7 @@ export class ImportService {
       for (const category of categories) {
         try {
           console.log(`Назначение сигналов для типа устройств: ${category}`);
-          const result = await ImportService.assignSignalsToDevicesByType(category);
+          const result = await ImportService.assignSignalsToDevicesByType(category, projectId);
           
           if (result.success) {
             totalAssignedCount += result.count || 0;


### PR DESCRIPTION
## Summary
- enable project filtering when assigning signals to devices
- update import controller to accept `projectId`
- document new API options for assigning signals per project

## Testing
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_683fdf6c64d8832782c21a40f6252c71