### PR TITLE
Fix device-type summary filtering

### DIFF
--- a/client/src/components/SignalDefinitions.tsx
+++ b/client/src/components/SignalDefinitions.tsx
@@ -199,7 +199,7 @@ const SignalDefinitions: React.FC<SignalDefinitionsProps> = ({ projectId }) => {
   const handleAssignSignalsToAllTypes = async () => {
     setLoading(true);
     try {
-      const result = await importService.assignSignalsToAllDeviceTypes();
+      const result = await importService.assignSignalsToAllDeviceTypes(projectId || undefined);
       if (result.success) {
         message.success(result.message);
         fetchSignals();

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -240,9 +240,13 @@ export const importService = {
   },
   
   // Назначение сигналов устройствам определенного типа
-  assignSignalsToDevicesByType: async (deviceType: string): Promise<{ success: boolean; message: string; count?: number }> => {
+  assignSignalsToDevicesByType: async (
+    deviceType: string,
+    projectId?: number
+  ): Promise<{ success: boolean; message: string; count?: number }> => {
     try {
-      const response = await api.post(`/import/assign-signals/${deviceType}`);
+      const query = projectId ? `?projectId=${projectId}` : '';
+      const response = await api.post(`/import/assign-signals/${deviceType}${query}`);
       return response.data;
     } catch (error) {
       console.error(`API: ошибка в assignSignalsToDevicesByType(${deviceType}):`, error);
@@ -251,9 +255,12 @@ export const importService = {
   },
   
   // Назначение сигналов всем типам устройств
-  assignSignalsToAllDeviceTypes: async (): Promise<{ success: boolean; message: string; count?: number }> => {
+  assignSignalsToAllDeviceTypes: async (
+    projectId?: number
+  ): Promise<{ success: boolean; message: string; count?: number }> => {
     try {
-      const response = await api.post('/import/assign-signals-all');
+      const query = projectId ? `?projectId=${projectId}` : '';
+      const response = await api.post(`/import/assign-signals-all${query}`);
       return response.data;
     } catch (error) {
       console.error('API: ошибка в assignSignalsToAllDeviceTypes:', error);

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,5 +15,7 @@
 | `GET` | `/api/device-type-signals` | Сигналы по типам устройств |
 | `PUT` | `/api/device-type-signals` | Создать или обновить запись |
 | `DELETE` | `/api/device-type-signals/:deviceType` | Удалить запись |
+| `POST` | `/api/import/assign-signals/:deviceType?projectId=ID` | Назначить сигналы устройствам указанного типа. Передайте `projectId` для ограничения назначения устройствами проекта |
+| `POST` | `/api/import/assign-signals-all?projectId=ID` | Назначить сигналы всем типам устройств. Укажите `projectId`, чтобы обрабатывать только текущий проект |
 
 Также доступны маршруты для импорта данных (`/api/import`), экспорта (`/api/exports`) и управления проектами (`/api/projects`).

--- a/server/src/controllers/deviceTypeSignalController.ts
+++ b/server/src/controllers/deviceTypeSignalController.ts
@@ -225,7 +225,9 @@ export const getSignalsSummary = async (req: Request, res: Response) => {
         
         // Добавляем фильтрацию по проекту, если указан
         if (projectId) {
-          signalCountsQuery += ` AND dr.project_id = ${parseInt(projectId as string, 10)}`
+          const pid = parseInt(projectId as string, 10);
+          signalCountsQuery += ` AND dr.project_id = ${pid}`;
+          signalCountsQuery += ` AND s.project_id = ${pid}`;
         }
         
         signalCountsQuery += ` GROUP BY dr.deviceType, s.type`;

--- a/server/src/controllers/importController.ts
+++ b/server/src/controllers/importController.ts
@@ -78,13 +78,15 @@ export class ImportController {
   static async assignSignalsToDevicesByType(req: Request, res: Response): Promise<void> {
     try {
       const { deviceType } = req.params;
+      const { projectId } = req.query;
       
       if (!deviceType) {
         res.status(400).json({ success: false, message: 'Не указан тип устройства' });
         return;
       }
       
-      const result = await ImportService.assignSignalsToDevicesByType(deviceType);
+      const pid = projectId ? parseInt(projectId as string, 10) : undefined;
+      const result = await ImportService.assignSignalsToDevicesByType(deviceType, pid);
       
       res.json(result);
     } catch (error) {
@@ -102,7 +104,9 @@ export class ImportController {
   static async assignSignalsToAllDeviceTypes(req: Request, res: Response): Promise<void> {
     try {
       console.log('Начато назначение сигналов всем типам устройств');
-      const result = await ImportService.assignSignalsToAllDeviceTypes();
+      const { projectId } = req.query;
+      const pid = projectId ? parseInt(projectId as string, 10) : undefined;
+      const result = await ImportService.assignSignalsToAllDeviceTypes(pid);
       
       res.json(result);
     } catch (error) {

--- a/server/src/services/ImportService.ts
+++ b/server/src/services/ImportService.ts
@@ -298,7 +298,7 @@ export class ImportService {
    * Привязка сигналов к устройствам на основе их типа
    * @param deviceType Тип устройства
    */
-  static async assignSignalsToDevicesByType(deviceType: string): Promise<{ success: boolean; message: string; count?: number }> {
+  static async assignSignalsToDevicesByType(deviceType: string, projectId?: number): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       // Получаем все сигналы для данной категории (типа устройства)
       const signals = await Signal.findAll({
@@ -314,8 +314,14 @@ export class ImportService {
       
       // Получаем все устройства данного типа
       const { DeviceReference } = require('../models/DeviceReference');
+      const whereClause: any = { deviceType };
+
+      if (projectId) {
+        whereClause.projectId = projectId;
+      }
+
       const devices = await DeviceReference.findAll({
-        where: { deviceType }
+        where: whereClause
       });
       
       if (devices.length === 0) {
@@ -454,7 +460,7 @@ export class ImportService {
   /**
    * Назначение сигналов всем типам устройств
    */
-  static async assignSignalsToAllDeviceTypes(): Promise<{ success: boolean; message: string; count?: number }> {
+  static async assignSignalsToAllDeviceTypes(projectId?: number): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       console.log('Начато назначение сигналов всем типам устройств');
       
@@ -492,7 +498,7 @@ export class ImportService {
       for (const category of categories) {
         try {
           console.log(`Назначение сигналов для типа устройств: ${category}`);
-          const result = await ImportService.assignSignalsToDevicesByType(category);
+          const result = await ImportService.assignSignalsToDevicesByType(category, projectId);
           
           if (result.success) {
             totalAssignedCount += result.count || 0;


### PR DESCRIPTION
## Summary
- filter signal counts by signal project id in device type summary

## Testing
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_683fdf6c64d8832782c21a40f6252c71