### PR TITLE
Fix project-based summary calculation

### DIFF
--- a/server/src/models/DeviceTypeSignal.ts
+++ b/server/src/models/DeviceTypeSignal.ts
@@ -8,6 +8,7 @@ interface DeviceTypeSignalAttributes {
   aoCount: number;
   diCount: number;
   doCount: number;
+  projectId?: number;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -19,6 +20,7 @@ export class DeviceTypeSignal extends Model<DeviceTypeSignalAttributes> implemen
   public aoCount!: number;
   public diCount!: number;
   public doCount!: number;
+  public projectId!: number;
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -60,6 +62,12 @@ export class DeviceTypeSignal extends Model<DeviceTypeSignalAttributes> implemen
           allowNull: false,
           defaultValue: 0,
           field: 'do_count'
+        },
+        projectId: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 1,
+          field: 'project_id'
         }
       },
       {


### PR DESCRIPTION
## Summary
- include `projectId` in `DeviceTypeSignal` model
- compute project-specific device types in `getSignalsSummary`
- rebuild client and server

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_683ff2ca6bac83278da21c83be42e902