### PR TITLE
Fix import uses chosen project

### DIFF
--- a/client/src/components/ImportData.tsx
+++ b/client/src/components/ImportData.tsx
@@ -4,6 +4,7 @@ import { UploadOutlined, InboxOutlined } from '@ant-design/icons';
 import { importService } from '../services/api';
 import type { UploadFile } from 'antd/es/upload/interface';
 import type { RcFile } from 'antd/es/upload';
+import { useProject } from '../contexts/ProjectContext';
 
 const { Dragger } = Upload;
 const { Title, Text } = Typography;
@@ -19,6 +20,8 @@ const ImportData: React.FC<ImportDataProps> = ({ onImportSuccess, onImportError 
   const [uploading, setUploading] = useState(false);
   const [importType, setImportType] = useState<'kip' | 'zra'>('kip');
   const [importProgress, setImportProgress] = useState(0);
+
+  const { currentProjectId } = useProject();
   
   // Получаем message из App
   const { message } = App.useApp();
@@ -71,9 +74,9 @@ const ImportData: React.FC<ImportDataProps> = ({ onImportSuccess, onImportError 
     try {
       let response;
       if (importType === 'kip') {
-        response = await importService.importKipFromCsv(file);
+        response = await importService.importKipFromCsv(file, currentProjectId || undefined);
       } else {
-        response = await importService.importZraFromCsv(file);
+        response = await importService.importZraFromCsv(file, currentProjectId || undefined);
       }
 
       // Завершаем прогресс

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -186,12 +186,16 @@ export const zraService = {
 // Сервис для работы с импортом данных
 export const importService = {
   // Импорт данных КИП из CSV файла
-  importKipFromCsv: async (file: File): Promise<{ success: boolean; message: string; count?: number }> => {
+  importKipFromCsv: async (
+    file: File,
+    projectId?: number
+  ): Promise<{ success: boolean; message: string; count?: number }> => {
     const formData = new FormData();
     formData.append('file', file);
     
     try {
-      const response = await api.post('/import/kip', formData, {
+      const query = projectId ? `?projectId=${projectId}` : '';
+      const response = await api.post(`/import/kip${query}`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },
@@ -204,12 +208,16 @@ export const importService = {
   },
   
   // Импорт данных ЗРА из CSV файла
-  importZraFromCsv: async (file: File): Promise<{ success: boolean; message: string; count?: number }> => {
+  importZraFromCsv: async (
+    file: File,
+    projectId?: number
+  ): Promise<{ success: boolean; message: string; count?: number }> => {
     const formData = new FormData();
     formData.append('file', file);
     
     try {
-      const response = await api.post('/import/zra', formData, {
+      const query = projectId ? `?projectId=${projectId}` : '';
+      const response = await api.post(`/import/zra${query}`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },

--- a/server/src/controllers/importController.ts
+++ b/server/src/controllers/importController.ts
@@ -12,10 +12,13 @@ export class ImportController {
         res.status(400).json({ success: false, message: 'Файл не найден' });
         return;
       }
-      
+
+      const { projectId } = req.query;
+      const pid = projectId ? parseInt(projectId as string, 10) : 1;
+
       const filePath = req.file.path;
-      const result = await ImportService.importKipFromCsv(filePath);
-      
+      const result = await ImportService.importKipFromCsv(filePath, pid);
+
       res.json(result);
     } catch (error) {
       console.error('Ошибка в контроллере импорта КИП:', error);
@@ -35,10 +38,13 @@ export class ImportController {
         res.status(400).json({ success: false, message: 'Файл не найден' });
         return;
       }
-      
+
+      const { projectId } = req.query;
+      const pid = projectId ? parseInt(projectId as string, 10) : 1;
+
       const filePath = req.file.path;
-      const result = await ImportService.importZraFromCsv(filePath);
-      
+      const result = await ImportService.importZraFromCsv(filePath, pid);
+
       res.json(result);
     } catch (error) {
       console.error('Ошибка в контроллере импорта ЗРА:', error);

--- a/server/src/services/ImportService.ts
+++ b/server/src/services/ImportService.ts
@@ -13,7 +13,10 @@ export class ImportService {
    * Импорт данных КИП из CSV файла
    * @param filePath Путь к CSV файлу
    */
-  static async importKipFromCsv(filePath: string): Promise<{ success: boolean; message: string; count?: number }> {
+  static async importKipFromCsv(
+    filePath: string,
+    projectId: number = 1
+  ): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       const results: any[] = [];
       
@@ -46,8 +49,13 @@ export class ImportService {
             defaults: {
               deviceType,
               description: row['Описание'] || '',
+              projectId
             }
           });
+
+          if (!created && deviceRef.projectId !== projectId) {
+            await deviceRef.update({ projectId });
+          }
           
           // Создаем запись КИП, связанную с устройством
           await Kip.create({
@@ -97,7 +105,10 @@ export class ImportService {
    * Импорт данных ЗРА из CSV файла
    * @param filePath Путь к CSV файлу
    */
-  static async importZraFromCsv(filePath: string): Promise<{ success: boolean; message: string; count?: number }> {
+  static async importZraFromCsv(
+    filePath: string,
+    projectId: number = 1
+  ): Promise<{ success: boolean; message: string; count?: number }> {
     try {
       const results: any[] = [];
       
@@ -130,8 +141,13 @@ export class ImportService {
             defaults: {
               deviceType: row['Конструктивное исполнение'] || 'Запорная арматура',
               description: row['Описание (ТЕМП)'] || '',
+              projectId
             }
           });
+
+          if (!created && deviceRef.projectId !== projectId) {
+            await deviceRef.update({ projectId });
+          }
           
           // Создаем запись ЗРА, связанную с устройством
           await Zra.create({


### PR DESCRIPTION
## Summary
- support projectId parameter for CSV imports on server
- pass current projectId from UI when importing data

## Testing
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_683ff978dd3083279a4f256a0b4e42ca