### PR TITLE
Fix import to keep devices per project

### DIFF
--- a/server/src/migrations/001_add_projects.sql
+++ b/server/src/migrations/001_add_projects.sql
@@ -42,6 +42,9 @@ CREATE INDEX IF NOT EXISTS idx_kips_project_id ON kips(project_id);
 CREATE INDEX IF NOT EXISTS idx_zras_project_id ON zras(project_id);
 CREATE INDEX IF NOT EXISTS idx_signals_project_id ON signals(project_id);
 CREATE INDEX IF NOT EXISTS idx_device_type_signals_project_id ON device_type_signals(project_id);
+-- Обновление уникального ограничения на device_references
+DROP INDEX IF EXISTS sqlite_autoindex_device_references_1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_references_proj_pos ON device_references(project_id, posDesignation);
 
 -- 6. Создание таблицы шаблонов проектов (для будущего использования)
 CREATE TABLE IF NOT EXISTS project_templates (

--- a/server/src/models/DeviceReference.ts
+++ b/server/src/models/DeviceReference.ts
@@ -37,7 +37,6 @@ export class DeviceReference extends Model<DeviceReferenceAttributes> implements
         posDesignation: {
           type: DataTypes.STRING,
           allowNull: false,
-          unique: true, // Уникальное позиционное обозначение
         },
         deviceType: {
           type: DataTypes.STRING,
@@ -77,7 +76,7 @@ export class DeviceReference extends Model<DeviceReferenceAttributes> implements
         indexes: [
           {
             unique: true,
-            fields: ['posDesignation'],
+            fields: ['project_id', 'posDesignation'],
           },
         ],
       }

--- a/server/src/scripts/runMigrationStep.ts
+++ b/server/src/scripts/runMigrationStep.ts
@@ -93,7 +93,9 @@ async function runMigrationStep() {
       'CREATE INDEX IF NOT EXISTS idx_kips_project_id ON kips(project_id)',
       'CREATE INDEX IF NOT EXISTS idx_zras_project_id ON zras(project_id)',
       'CREATE INDEX IF NOT EXISTS idx_signals_project_id ON signals(project_id)',
-      'CREATE INDEX IF NOT EXISTS idx_device_type_signals_project_id ON device_type_signals(project_id)'
+      'CREATE INDEX IF NOT EXISTS idx_device_type_signals_project_id ON device_type_signals(project_id)',
+      'DROP INDEX IF EXISTS sqlite_autoindex_device_references_1',
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_device_references_proj_pos ON device_references(project_id, posDesignation)'
     ];
     
     for (const indexSQL of indexes) {

--- a/server/src/services/ImportService.ts
+++ b/server/src/services/ImportService.ts
@@ -45,7 +45,7 @@ export class ImportService {
           
           // Создаем или находим запись в справочнике устройств
           const [deviceRef, created] = await DeviceReference.findOrCreate({
-            where: { posDesignation },
+            where: { posDesignation, projectId },
             defaults: {
               deviceType,
               description: row['Описание'] || '',
@@ -137,7 +137,7 @@ export class ImportService {
           
           // Создаем или находим запись в справочнике устройств
           const [deviceRef, created] = await DeviceReference.findOrCreate({
-            where: { posDesignation },
+            where: { posDesignation, projectId },
             defaults: {
               deviceType: row['Конструктивное исполнение'] || 'Запорная арматура',
               description: row['Описание (ТЕМП)'] || '',


### PR DESCRIPTION
## Summary
- allow same device position in different projects
- search device references by project in import service
- update migrations to create composite unique index
- adjust migration script to drop old unique index

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc14aed48327b8f8b141e79b1006