### PR TITLE
Fix project associations

### DIFF
--- a/server/src/controllers/deviceTypeSignalController.ts
+++ b/server/src/controllers/deviceTypeSignalController.ts
@@ -165,8 +165,7 @@ export const getSignalsSummary = async (req: Request, res: Response) => {
           aiCount: 0,
           aoCount: 0,
           diCount: 0,
-          doCount: 0,
-          projectId: parseInt(projectId as string, 10)
+          doCount: 0
         })
       );
     } else {

--- a/server/src/models/Device.ts
+++ b/server/src/models/Device.ts
@@ -10,6 +10,7 @@ interface DeviceAttributes {
   deviceType: string;
   description: string;
   parentId?: number | null;
+  projectId: number;
 }
 
 export class Device extends Model<DeviceAttributes> implements DeviceAttributes {
@@ -22,6 +23,7 @@ export class Device extends Model<DeviceAttributes> implements DeviceAttributes 
   public deviceType!: string;
   public description!: string;
   public parentId!: number | null;
+  public projectId!: number;
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -70,6 +72,12 @@ export class Device extends Model<DeviceAttributes> implements DeviceAttributes 
             key: 'id',
           },
         },
+        projectId: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 1,
+          field: 'project_id',
+        },
       },
       {
         sequelize,
@@ -88,7 +96,13 @@ export class Device extends Model<DeviceAttributes> implements DeviceAttributes 
       foreignKey: 'parentId',
       as: 'parent',
     });
-    
+
+    const { Project } = require('./Project');
+    Device.belongsTo(Project, {
+      foreignKey: 'projectId',
+      as: 'project',
+    });
+
     // Связь с DeviceSignal будет добавлена после инициализации DeviceSignal
   }
-} 
+}

--- a/server/src/models/DeviceTypeSignal.ts
+++ b/server/src/models/DeviceTypeSignal.ts
@@ -8,7 +8,6 @@ interface DeviceTypeSignalAttributes {
   aoCount: number;
   diCount: number;
   doCount: number;
-  projectId?: number;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -20,7 +19,6 @@ export class DeviceTypeSignal extends Model<DeviceTypeSignalAttributes> implemen
   public aoCount!: number;
   public diCount!: number;
   public doCount!: number;
-  public projectId!: number;
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -62,12 +60,6 @@ export class DeviceTypeSignal extends Model<DeviceTypeSignalAttributes> implemen
           allowNull: false,
           defaultValue: 0,
           field: 'do_count'
-        },
-        projectId: {
-          type: DataTypes.INTEGER,
-          allowNull: false,
-          defaultValue: 1,
-          field: 'project_id'
         }
       },
       {


### PR DESCRIPTION
## Summary
- add projectId field and association to Device
- make DeviceTypeSignal independent from projects
- fix controller to stop setting projectId field

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684135fd0070832784f71bdbaf31505e